### PR TITLE
Fix #2 - Live mode freqently displays React error

### DIFF
--- a/src/ui/Dashboard.tsx
+++ b/src/ui/Dashboard.tsx
@@ -186,7 +186,6 @@ export const Dashboard = ({
       });
     };
 
-    handleResize();
     stdout.on('resize', handleResize);
 
     return () => {


### PR DESCRIPTION
Fixes React 18 error: "Cannot update a component while rendering a different component" by removing the immediate handleResize() call from the useEffect.

The terminalSize state is already correctly initialized in the useState hook with stdout.columns and stdout.rows values, making the immediate call redundant. The resize event listener remains functional for actual resize events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated resize event handling behavior to defer terminal size updates until the first resize event occurs, rather than immediately on load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->